### PR TITLE
feat(cloudnative-pg): add plugin-barman-cloud deployment

### DIFF
--- a/kubernetes/apps/cloudnative-pg/helm-release-plugin-barman-cloud.yaml
+++ b/kubernetes/apps/cloudnative-pg/helm-release-plugin-barman-cloud.yaml
@@ -1,0 +1,30 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name plugin-barman-cloud
+  namespace: flux-system
+spec:
+  interval: 30m
+  chartRef:
+    kind: OCIRepository
+    name: plugin-barman-cloud
+  driftDetection:
+    mode: enabled
+  targetNamespace: cloudnative-pg
+  maxHistory: 3
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      retries: 10
+  dependsOn:
+    - name: cloudnative-pg
+      namespace: flux-system
+  values:
+    fullnameOverride: *name
+    crds:
+      create: true

--- a/kubernetes/apps/cloudnative-pg/kustomization.yaml
+++ b/kubernetes/apps/cloudnative-pg/kustomization.yaml
@@ -3,5 +3,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - helm-release.yaml
+  - helm-release-plugin-barman-cloud.yaml
   - networkpolicy.yaml
+  - oci-repository-plugin-barman-cloud.yaml
   - prometheus_rules.yaml

--- a/kubernetes/apps/cloudnative-pg/networkpolicy.yaml
+++ b/kubernetes/apps/cloudnative-pg/networkpolicy.yaml
@@ -47,6 +47,50 @@ spec:
         - port: 8000
           protocol: TCP
 ---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: plugin-barman-cloud
+  namespace: cloudnative-pg
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: plugin-barman-cloud
+  policyTypes:
+    - Ingress
+    - Egress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: comics
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: database
+              app.kubernetes.io/managed-by: cloudnative-pg
+              app.kubernetes.io/name: postgresql
+              cnpg.io/podRole: instance
+      ports:
+        - port: 9090
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - port: 53
+          protocol: UDP
+    - to: # S3-Backup
+      - ipBlock:
+          cidr: 10.0.1.75/32
+      ports:
+        - port: 3900
+          protocol: TCP
+---
 apiVersion: cilium.io/v2
 kind: CiliumNetworkPolicy
 metadata:
@@ -57,6 +101,24 @@ spec:
     matchLabels:
       app.kubernetes.io/instance: cloudnative-pg-cloudnative-pg
       app.kubernetes.io/name: cloudnative-pg
+  egress:
+    - toEntities:
+      - kube-apiserver
+  ingress:
+    - fromEntities:
+      - kube-apiserver
+      - remote-node
+      - host
+---
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: plugin-barman-cloud
+  namespace: cloudnative-pg
+spec:
+  endpointSelector:
+    matchLabels:
+      app.kubernetes.io/name: plugin-barman-cloud
   egress:
     - toEntities:
       - kube-apiserver

--- a/kubernetes/apps/cloudnative-pg/oci-repository-plugin-barman-cloud.yaml
+++ b/kubernetes/apps/cloudnative-pg/oci-repository-plugin-barman-cloud.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: plugin-barman-cloud
+  namespace: flux-system
+spec:
+  interval: 30m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.5.0
+  url: oci://ghcr.io/cloudnative-pg/charts/plugin-barman-cloud

--- a/kubernetes/apps/cloudnative-pg/prometheus_rules.yaml
+++ b/kubernetes/apps/cloudnative-pg/prometheus_rules.yaml
@@ -42,6 +42,14 @@ spec:
           groups:
             - name: cloudnative-pg.rules
               rules:
+                # NOTE: When migrating to plugin-barman-cloud, the following
+                # Prometheus metrics are deprecated and will no longer update
+                # for plugin-based backups (CNPG ≥1.26.1):
+                #   - cnpg_collector_first_recoverability_point
+                #   - cnpg_collector_last_available_backup_timestamp
+                #   - cnpg_collector_last_failed_backup_timestamp
+                # The alerts below use pg_stat_archiver metrics which remain
+                # functional with both inline and plugin-based backup methods.
                 - alert: LongRunningTransaction
                   annotations:
                     description: Pod {{ $labels.pod }} is taking more than 5 minutes (300 seconds) for a query.


### PR DESCRIPTION
Deploy plugin-barman-cloud to the cloudnative-pg namespace.

- OCIRepository + HelmRelease (v0.5.0)
- NetworkPolicy: ingress from comics DB pods on 9090, egress to DNS + S3
- CiliumNetworkPolicy: kube-apiserver access
- Deprecation note in prometheus_rules for metrics that stop updating with plugin backups