### PR TITLE
chore: auto-merge digest updates for ghcr.io/davralin/openclaw

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -87,6 +87,7 @@
         '/ghcr.io/claabs/epicgames-freegames-node/',
         '/ghcr.io/chrisbenincasa/tunarr/',
         '/ghcr.io/corentinth/it-tools/',
+        '/ghcr.io/davralin/openclaw/',
         '/docker.io/davralin/',
         '/ghcr.io/meshtastic/web/',
         '/ghcr.io/home-operations/',


### PR DESCRIPTION
Adds `ghcr.io/davralin/openclaw/` to the Renovate digest auto-merge allowlist, so future digest-only updates merge automatically without manual intervention.