### PR TITLE
feat(litellm): add VolSync backup

### DIFF
--- a/kubernetes/apps/litellm/kustomization.yaml
+++ b/kubernetes/apps/litellm/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
   - networkpolicy.yaml
   - probes.yaml
   - pvc.yaml
+  - volsync.yaml
+

--- a/kubernetes/apps/litellm/volsync.yaml
+++ b/kubernetes/apps/litellm/volsync.yaml
@@ -1,0 +1,100 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name litellm-restic
+  namespace: &namespace litellm
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: raw
+      version: v0.3.2
+      sourceRef:
+        kind: HelmRepository
+        name: dysnix-charts
+        namespace: flux-system
+      interval: 30m
+  driftDetection:
+    mode: enabled
+  targetNamespace: litellm
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    remediation:
+      retries: 10
+  dependsOn:
+    - name: volsync
+      namespace: flux-system
+    - name: litellm
+      namespace: flux-system
+  values:
+    resources:
+      - apiVersion: v1
+        kind: Secret
+        metadata:
+          name: litellm-volsync-secret
+          namespace: litellm
+        type: Opaque
+        stringData:
+          RESTIC_REPOSITORY: "s3:${SECRET_S3_VOLSYNC_URL}/volsync-${CLUSTER_NAME}/litellm"
+          RESTIC_PASSWORD: "${SECRET_VOLSYNC_RESTIC_PWD}"
+          AWS_ACCESS_KEY_ID: "${SECRET_S3_VOLSYNC_ACCESS_KEYS}"
+          AWS_SECRET_ACCESS_KEY: "${SECRET_S3_VOLSYNC_SECRET_KEYS}"
+      - apiVersion: volsync.backube/v1alpha1
+        kind: ReplicationSource
+        metadata:
+          name: *name
+          namespace: *namespace
+        spec:
+          sourcePVC: litellm
+          trigger:
+            schedule: "14 02 * * *"
+          restic:
+            copyMethod: Direct
+            pruneIntervalDays: 7
+            repository: litellm-volsync-secret
+            moverSecurityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
+              fsGroup: 1000
+              fsGroupChangePolicy: "OnRootMismatch"
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+            retain:
+              daily: 7
+              within: 3d
+      - apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        metadata:
+          name: *name
+          namespace: *namespace
+        spec:
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/created-by: volsync
+          policyTypes:
+            - Ingress
+            - Egress
+          ingress: []
+          egress:
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+                  podSelector:
+                    matchLabels:
+                      k8s-app: kube-dns
+              ports:
+                - port: 53
+                  protocol: UDP
+            - to: # S3-Backup
+              - ipBlock:
+                  cidr: 10.0.1.75/32
+              ports:
+                - port: 3900
+                  protocol: TCP
+


### PR DESCRIPTION
Add VolSync Restic backup for the LiteLLM PVC.

- Schedule: `14 02 * * *` (staggered from other apps)
- Retention: 7 daily, within 3d
- Includes NetworkPolicy for volsync mover pods