### PR TITLE
fix(renovate): add commit message prefix for immich group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -51,6 +51,8 @@
       matchPackageNames: [
         '/immich/',
       ],
+      commitMessagePrefix: 'fix(deps): ',
+      commitMessageTopic: '{{groupName}}',
     },
     {
       description: 'Group tdarr and tdarr_node container updates',


### PR DESCRIPTION
Grouped PRs fall back to `chore(deps)` instead of following per-datasource commit message rules. Adds explicit `fix(deps):` prefix so immich updates display correctly.