### PR TITLE
fix(renovate): remove commitMessageTopic override for immich group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -52,7 +52,6 @@
         '/immich/',
       ],
       commitMessagePrefix: 'fix(deps): ',
-      commitMessageTopic: '{{groupName}}',
     },
     {
       description: 'Group tdarr and tdarr_node container updates',


### PR DESCRIPTION
The `commitMessageTopic: {{groupName}}` I added in #6736 replaced the default dependency name + version range, resulting in titles like `fix(deps): Update to v2.7.4` with no package name. Removing the topic override lets Renovate build the full title normally.