### PR TITLE
feat(openclaw): add alertmanager egress to network policy

### DIFF
--- a/kubernetes/apps/openclaw/helm-release.yaml
+++ b/kubernetes/apps/openclaw/helm-release.yaml
@@ -311,6 +311,16 @@ spec:
               ports:
                 - port: 9090
                   protocol: TCP
+            - ports:
+                - port: 9093
+                  protocol: TCP
+              to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: monitoring
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: alertmanager
             - to:
                 - namespaceSelector:
                     matchLabels:


### PR DESCRIPTION
Adds an egress rule to the OpenClaw network policy allowing traffic to Alertmanager on port 9093 (TCP) in the `monitoring` namespace. This enables OpenClaw to query cluster health alerts from Alertmanager.