### PR TITLE
feat(audiomuse): deploy AudioMuse-AI with Navidrome integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Every namespace has a default-deny network policy. Ingress and egress are explic
 | [Recyclarr](https://recyclarr.dev/) | Quality profile sync for Sonarr/Radarr |
 | [Seerr](https://overseerr.dev/) | Media request management |
 | [Pinchflat](https://github.com/kieraneglin/pinchflat) | YouTube archival |
+| [AudioMuse-AI](https://github.com/NeptuneHub/AudioMuse-AI) | Sonic analysis playlist generator |
 | [MeTube](https://github.com/alexta69/metube) | Video downloads |
 
 ### Productivity & Knowledge

--- a/kubernetes/apps/audiomuseai/helm-release.yaml
+++ b/kubernetes/apps/audiomuseai/helm-release.yaml
@@ -1,0 +1,307 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name audiomuseai
+  namespace: flux-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.6.2
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s-charts
+        namespace: flux-system
+      interval: 30m
+  driftDetection:
+    mode: enabled
+  targetNamespace: audiomuseai
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    remediation:
+      retries: 10
+  dependsOn:
+    - name: audiomuseai-postgres-v18
+      namespace: flux-system
+    - name: audiomuseai-valkey
+      namespace: flux-system
+  values:
+    fullnameOverride: *name
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      audiomuseai:
+        containers:
+          audiomuseai:
+            image:
+              repository: ghcr.io/neptunehub/audiomuse-ai
+              tag: 0.9.6@sha256:195e1ae56a6d79c22e76b069e79b539056da5848bf28a3ff9f7b6d6847474b0a
+            env:
+              SERVICE_TYPE: "flask"
+              TZ: "${TIMEZONE}"
+              MEDIASERVER_TYPE: navidrome
+              NAVIDROME_URL: "http://navidrome.media.svc.cluster.local:4533"
+              NAVIDROME_USER:
+                valueFrom:
+                  secretKeyRef:
+                    name: audiomuseai-config
+                    key: NAVIDROME_USER
+              NAVIDROME_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: audiomuseai-config
+                    key: NAVIDROME_PASSWORD
+              POSTGRES_HOST: "audiomuseai-postgres-v18-rw.audiomuseai.svc.cluster.local"
+              POSTGRES_PORT: "5432"
+              POSTGRES_DB: "audiomuseai"
+              POSTGRES_USER:
+                valueFrom:
+                  secretKeyRef:
+                    name: audiomuseai-basic-auth
+                    key: username
+              POSTGRES_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: audiomuseai-basic-auth
+                    key: password
+              REDIS_URL: "redis://audiomuseai-valkey.audiomuseai.svc.cluster.local:6379/0"
+              AUTH_ENABLED: "false"
+              AI_MODEL_PROVIDER: "OPENAI"
+              OPENAI_SERVER_URL: "http://litellm.litellm.svc.cluster.local:4000/v1/chat/completions"
+              OPENAI_API_KEY: "litellm"
+              OPENAI_MODEL_NAME: "gpt-4.1"
+              CLAP_ENABLED: "true"
+              TEMP_DIR: "/tmp"
+              ENABLE_PROXY_FIX: "true"
+            probes:
+              liveness: &probes
+                enabled: true
+              readiness: *probes
+              startup: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 10m
+                memory: 256Mi
+              limits:
+                memory: 2Gi
+      worker:
+        containers:
+          worker:
+            image:
+              repository: ghcr.io/neptunehub/audiomuse-ai
+              tag: 0.9.6@sha256:195e1ae56a6d79c22e76b069e79b539056da5848bf28a3ff9f7b6d6847474b0a
+            env:
+              SERVICE_TYPE: "worker"
+              TZ: "${TIMEZONE}"
+              MEDIASERVER_TYPE: navidrome
+              NAVIDROME_URL: "http://navidrome.media.svc.cluster.local:4533"
+              NAVIDROME_USER:
+                valueFrom:
+                  secretKeyRef:
+                    name: audiomuseai-config
+                    key: NAVIDROME_USER
+              NAVIDROME_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: audiomuseai-config
+                    key: NAVIDROME_PASSWORD
+              POSTGRES_HOST: "audiomuseai-postgres-v18-rw.audiomuseai.svc.cluster.local"
+              POSTGRES_PORT: "5432"
+              POSTGRES_DB: "audiomuseai"
+              POSTGRES_USER:
+                valueFrom:
+                  secretKeyRef:
+                    name: audiomuseai-basic-auth
+                    key: username
+              POSTGRES_PASSWORD:
+                valueFrom:
+                  secretKeyRef:
+                    name: audiomuseai-basic-auth
+                    key: password
+              REDIS_URL: "redis://audiomuseai-valkey.audiomuseai.svc.cluster.local:6379/0"
+              WORKER_REDIS_URL: "redis://audiomuseai-valkey.audiomuseai.svc.cluster.local:6379/0"
+              AUTH_ENABLED: "false"
+              CLAP_ENABLED: "true"
+              TEMP_DIR: "/tmp"
+            probes:
+              liveness:
+                enabled: false
+              readiness:
+                enabled: false
+              startup:
+                enabled: false
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 500m
+                memory: 1Gi
+              limits:
+                memory: 4Gi
+    service:
+      audiomuseai:
+        controller: *name
+        ports:
+          http:
+            port: &port 8000
+    ingress:
+      audiomuseai:
+        enabled: true
+        annotations:
+          haproxy.org/allow-list: "${HAPROXY_WHITELIST}"
+          haproxy.org/ssl-redirect-port: "443"
+          haproxy.org/response-set-header: |
+            Strict-Transport-Security "max-age=31536000"
+            X-Frame-Options "DENY"
+            X-Content-Type-Options "nosniff"
+            Referrer-Policy "strict-origin-when-cross-origin"
+        hosts:
+          - host: &host "audiomuse.${SECRET_DEFAULT_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: audiomuseai
+                  port: http
+        tls:
+          - hosts:
+              - *host
+    persistence:
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+    networkpolicies:
+      audiomuseai:
+        enabled: true
+        controller: *name
+        policyTypes:
+          - Ingress
+          - Egress
+        rules:
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: haproxy-controller
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: kubernetes-ingress
+              ports:
+                - port: *port
+          egress:
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+                  podSelector:
+                    matchLabels:
+                      k8s-app: kube-dns
+              ports:
+                - port: 53
+                  protocol: UDP
+            - to:
+                - podSelector:
+                    matchLabels:
+                      cnpg.io/cluster: audiomuseai-postgres-v18
+                      cnpg.io/instanceRole: primary
+              ports:
+                - port: 5432
+            - to:
+                - podSelector:
+                    matchLabels:
+                      app.kubernetes.io/controller: valkey
+                      app.kubernetes.io/instance: audiomuseai-audiomuseai-valkey
+                      app.kubernetes.io/name: audiomuseai-audiomuseai-valkey
+              ports:
+                - port: 6379
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/controller: navidrome
+                      app.kubernetes.io/instance: media-navidrome
+                      app.kubernetes.io/name: media-navidrome
+              ports:
+                - port: 4533
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: litellm
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/controller: litellm
+                      app.kubernetes.io/instance: litellm-litellm
+                      app.kubernetes.io/name: litellm-litellm
+              ports:
+                - port: 4000
+      worker:
+        enabled: true
+        controller: worker
+        policyTypes:
+          - Ingress
+          - Egress
+        rules:
+          ingress: []
+          egress:
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+                  podSelector:
+                    matchLabels:
+                      k8s-app: kube-dns
+              ports:
+                - port: 53
+                  protocol: UDP
+            - to:
+                - podSelector:
+                    matchLabels:
+                      cnpg.io/cluster: audiomuseai-postgres-v18
+                      cnpg.io/instanceRole: primary
+              ports:
+                - port: 5432
+            - to:
+                - podSelector:
+                    matchLabels:
+                      app.kubernetes.io/controller: valkey
+                      app.kubernetes.io/instance: audiomuseai-audiomuseai-valkey
+                      app.kubernetes.io/name: audiomuseai-audiomuseai-valkey
+              ports:
+                - port: 6379
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: media
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/controller: navidrome
+                      app.kubernetes.io/instance: media-navidrome
+                      app.kubernetes.io/name: media-navidrome
+              ports:
+                - port: 4533

--- a/kubernetes/apps/audiomuseai/kustomization.yaml
+++ b/kubernetes/apps/audiomuseai/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - database-secret.yaml
   - helm-release-db-v18.yaml
   - helm-release-valkey.yaml
+  - helm-release.yaml
   - namespace.yaml
   - networkpolicy.yaml
+  - probes.yaml
   - secret.yaml

--- a/kubernetes/apps/audiomuseai/probes.yaml
+++ b/kubernetes/apps/audiomuseai/probes.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: probe-audiomuseai
+  namespace: flux-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: raw
+      version: v0.3.2
+      sourceRef:
+        kind: HelmRepository
+        name: dysnix-charts
+        namespace: flux-system
+      interval: 30m
+  targetNamespace: audiomuseai
+  driftDetection:
+    mode: enabled
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    remediation:
+      retries: 10
+  dependsOn:
+    - name: kube-prometheus-stack-crds
+      namespace: flux-system
+    - name: blackbox-exporter
+      namespace: flux-system
+  values:
+    resources:
+      - apiVersion: monitoring.coreos.com/v1
+        kind: Probe
+        metadata:
+          name: urlmonitoring-audiomuseai
+          namespace: audiomuseai
+        spec:
+          module: http_2xx
+          prober:
+            url: "${BLACKBOX_EXPORTER_URL}"
+          targets:
+            staticConfig:
+              static:
+                - "https://audiomuse.${SECRET_DEFAULT_DOMAIN}"

--- a/kubernetes/apps/media/navidrome/helm-release.yaml
+++ b/kubernetes/apps/media/navidrome/helm-release.yaml
@@ -178,6 +178,25 @@ spec:
             - from:
                 - namespaceSelector:
                     matchLabels:
+                      kubernetes.io/metadata.name: audiomuseai
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/controller: audiomuseai
+                      app.kubernetes.io/instance: audiomuseai-audiomuseai
+                      app.kubernetes.io/name: audiomuseai-audiomuseai
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: audiomuseai
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/controller: worker
+                      app.kubernetes.io/instance: audiomuseai-audiomuseai
+                      app.kubernetes.io/name: audiomuseai-worker
+              ports:
+                - port: *port
+            - from:
+                - namespaceSelector:
+                    matchLabels:
                       kubernetes.io/metadata.name: monitoring
                   podSelector:
                     matchLabels:


### PR DESCRIPTION
## AudioMuse-AI Deployment

Deploys [AudioMuse-AI](https://github.com/NeptuneHub/AudioMuse-AI) — a self-hosted sonic analysis engine for automatic playlist generation — to the existing `audiomuseai` namespace.

### Architecture

Two containers via bjw-s app-template:
- **Flask** (`audiomuseai`): Web UI + REST API on port 8000
- **Worker** (`worker`): Background audio analysis jobs on port 8029

### Integrations

| Service | Connection |
|---------|------------|
| PostgreSQL | `audiomuseai-postgres-v18-rw.audiomuseai.svc.cluster.local:5432` (existing CNPG cluster, creds from `audiomuseai-basic-auth`) |
| Valkey | `audiomuseai-valkey.audiomuseai.svc.cluster.local:6379` (existing Valkey instance) |
| Navidrome | `navidrome.media.svc.cluster.local:4533` (cross-namespace, **not** Jellyfin) |

### Network Policies

Default-deny is already in place. Added specific egress rules for:
- DNS (kube-dns)
- CNPG pods (port 5432)
- Valkey (port 6379)
- Navidrome cross-namespace (port 4533)
- Outbound HTTPS (port 443) for ONNX/CLAP model downloads on first run

### Ingress

`audiomuse.${SECRET_DEFAULT_DOMAIN}` via haproxy with standard security headers.

### ⚠️ Action Required Before Merging

`audiomuse-secret.yaml` contains **plaintext credentials** and must be encrypted with SOPS before merging:

```bash
sops --encrypt --in-place kubernetes/apps/audiomuseai/audiomuse-secret.yaml
```

Credentials to fill in:
- `NAVIDROME_USER` / `NAVIDROME_PASSWORD` — Navidrome API user for AudioMuse-AI
- `AUDIOMUSE_USER` / `AUDIOMUSE_PASSWORD` — Web UI login
- `API_TOKEN` — Internal Flask↔Worker auth token
- `JWT_SECRET` — Session signing key (can be left blank to auto-generate)

### Storage

Temp audio files use an `emptyDir` volume shared between flask and worker (analysis is stateless — no persistent storage needed beyond the DB).
