### PR TITLE
feat(excalidraw): add self-hosted whiteboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Every namespace has a default-deny network policy. Ingress and egress are explic
 ### Development & DevOps
 | Service | Purpose |
 |---------|---------|
+| [Excalidraw](https://excalidraw.com/) | Self-hosted collaborative whiteboard |
 | [Forgejo](https://forgejo.org/) | Self-hosted Git forge |
 | [JupyterHub](https://jupyter.org/hub) | Multi-user notebook environment |
 | [OpenCode](https://github.com/AnomalyHQ/opencode) | AI coding agent |

--- a/kubernetes/apps/excalidraw/helm-release.yaml
+++ b/kubernetes/apps/excalidraw/helm-release.yaml
@@ -1,0 +1,118 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name excalidraw
+  namespace: flux-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.6.2
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s-charts
+        namespace: flux-system
+      interval: 30m
+  driftDetection:
+    mode: enabled
+  targetNamespace: excalidraw
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    remediation:
+      retries: 10
+  values:
+    fullnameOverride: *name
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsUser: 65534
+        runAsGroup: 65534
+        fsGroup: 65534
+        fsGroupChangePolicy: "OnRootMismatch"
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      excalidraw:
+        strategy: RollingUpdate
+        containers:
+          excalidraw:
+            image:
+              repository: docker.io/excalidraw/excalidraw
+              tag: latest@sha256:3c2513e830bb6e195147c05b34ecf8393d0ba2b1cc86e93b407a5777d6135c6c
+            env:
+              TZ: "${TIMEZONE}"
+            probes:
+              liveness: &probes
+                enabled: true
+              readiness: *probes
+              startup: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 10m
+                memory: 50M
+              limits:
+                memory: 100M
+    service:
+      excalidraw:
+        controller: *name
+        ports:
+          http:
+            port: &port 80
+    ingress:
+      excalidraw:
+        enabled: true
+        annotations:
+          haproxy.org/allow-list: "${HAPROXY_WHITELIST}"
+          haproxy.org/ssl-redirect-port: "443"
+          haproxy.org/response-set-header: |
+            Strict-Transport-Security "max-age=31536000"
+            X-Frame-Options "DENY"
+            X-Content-Type-Options "nosniff"
+            Referrer-Policy "strict-origin-when-cross-origin"
+        hosts:
+          - host: &host "draw.${SECRET_DEFAULT_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: excalidraw
+                  port: http
+        tls:
+          - hosts:
+              - *host
+    persistence:
+      tmp:
+        type: emptyDir
+        globalMounts:
+          - path: /tmp
+    networkpolicies:
+      excalidraw:
+        enabled: true
+        controller: *name
+        policyTypes:
+          - Ingress
+          - Egress
+        rules:
+          egress: []
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: haproxy-controller
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: kubernetes-ingress
+              ports:
+                - port: *port

--- a/kubernetes/apps/excalidraw/kustomization.yaml
+++ b/kubernetes/apps/excalidraw/kustomization.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml
+  - namespace.yaml
+  - networkpolicy.yaml
+  - probes.yaml

--- a/kubernetes/apps/excalidraw/namespace.yaml
+++ b/kubernetes/apps/excalidraw/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: excalidraw

--- a/kubernetes/apps/excalidraw/networkpolicy.yaml
+++ b/kubernetes/apps/excalidraw/networkpolicy.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: excalidraw
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/kubernetes/apps/excalidraw/probes.yaml
+++ b/kubernetes/apps/excalidraw/probes.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: probe
+  namespace: excalidraw
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: raw
+      version: v0.3.2
+      sourceRef:
+        kind: HelmRepository
+        name: dysnix-charts
+        namespace: flux-system
+      interval: 30m
+  targetNamespace: excalidraw
+  driftDetection:
+    mode: enabled
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    remediation:
+      retries: 10
+  dependsOn:
+    - name: kube-prometheus-stack-crds
+      namespace: flux-system
+    - name: blackbox-exporter
+      namespace: flux-system
+  values:
+    resources:
+      - apiVersion: monitoring.coreos.com/v1
+        kind: Probe
+        metadata:
+          name: urlmonitoring
+          namespace: excalidraw
+        spec:
+          module: http_2xx
+          prober:
+            url: "${BLACKBOX_EXPORTER_URL}"
+          targets:
+            staticConfig:
+              static:
+                - "https://draw.${SECRET_DEFAULT_DOMAIN}"

--- a/kubernetes/apps/homeprod/kustomization.yaml
+++ b/kubernetes/apps/homeprod/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ../cloudnative-pg
   - ../comics
   - ../cyberchef
+  - ../excalidraw
   - ../dawarich
   - ../descheduler
   - ../endurain


### PR DESCRIPTION
Adds Excalidraw as a self-hosted collaborative whiteboard app.

- nginx-based static site, no persistence, no egress
- Image pinned with digest
- Follows cyberchef conventions (UID/GID 65534, readOnlyRootFilesystem: false)
- Includes blackbox probe, default-deny NetworkPolicy, HAProxy ingress