### PR TITLE
fix(excalidraw): add nginx cache emptyDir for write access

### DIFF
--- a/kubernetes/apps/excalidraw/helm-release.yaml
+++ b/kubernetes/apps/excalidraw/helm-release.yaml
@@ -93,10 +93,10 @@ spec:
           - hosts:
               - *host
     persistence:
-      tmp:
+      var-cache-nginx:
         type: emptyDir
-        globalMounts:
-          - path: /tmp
+      var-run:
+        type: emptyDir
     networkpolicies:
       excalidraw:
         enabled: true


### PR DESCRIPTION
Nginx needs write access to `/var/cache/nginx` and `/var/run` for pid/cache files. Adds emptyDir mounts using app-template auto-mount convention (key = mount path).