### PR TITLE
feat(media): add ersatztv-next deployment

### DIFF
--- a/kubernetes/apps/media/ersatztv-next/helm-release.yaml
+++ b/kubernetes/apps/media/ersatztv-next/helm-release.yaml
@@ -1,0 +1,119 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name ersatztv-next
+  namespace: flux-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.6.2
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s-charts
+        namespace: flux-system
+      interval: 30m
+  driftDetection:
+    mode: enabled
+  targetNamespace: media
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    remediation:
+      retries: 10
+  values:
+    fullnameOverride: *name
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      ersatztv-next:
+        containers:
+          ersatztv-next:
+            image:
+              repository: ghcr.io/ersatztv/ersatztv-next
+              tag: latest
+            env:
+              TZ: "${TIMEZONE}"
+            probes:
+              liveness: &probes
+                enabled: true
+              readiness: *probes
+              startup: *probes
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 10m
+                memory: 256Mi
+              limits:
+                memory: 1Gi
+    service:
+      ersatztv-next:
+        controller: *name
+        ports:
+          http:
+            port: &port 8409
+    persistence:
+      config:
+        enabled: true
+        existingClaim: ersatztv-next
+        globalMounts:
+          - path: /config
+      media:
+        enabled: true
+        existingClaim: media
+        advancedMounts:
+          ersatztv-next:
+            ersatztv-next:
+              - path: /data
+                subPath: .
+                readOnly: true
+      tmp:
+        enabled: true
+        type: emptyDir
+    networkpolicies:
+      ersatztv-next:
+        enabled: true
+        controller: *name
+        policyTypes:
+          - Ingress
+          - Egress
+        rules:
+          egress:
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+                  podSelector:
+                    matchLabels:
+                      k8s-app: kube-dns
+              ports:
+                - port: 53
+                  protocol: UDP
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: haproxy-controller
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: kubernetes-ingress
+              ports:
+                - port: *port

--- a/kubernetes/apps/media/ersatztv-next/helm-release.yaml
+++ b/kubernetes/apps/media/ersatztv-next/helm-release.yaml
@@ -85,4 +85,20 @@ spec:
               - path: /data
                 subPath: .
                 readOnly: true
+    networkpolicies:
+      ersatztv-next:
+        enabled: true
+        controller: *name
+        policyTypes:
+          - Ingress
+        rules:
+          ingress:
+            - from:
+                - podSelector:
+                    matchLabels:
+                      app.kubernetes.io/controller: jellyfin
+                      app.kubernetes.io/instance: media-jellyfin
+                      app.kubernetes.io/name: media-jellyfin
+              ports:
+                - port: *port
 

--- a/kubernetes/apps/media/ersatztv-next/helm-release.yaml
+++ b/kubernetes/apps/media/ersatztv-next/helm-release.yaml
@@ -45,6 +45,7 @@ spec:
             image:
               repository: ghcr.io/ersatztv/ersatztv-next
               tag: develop
+              # digest: sha256:TODO — pin after pulling (image requires GHCR auth)
             env:
               TZ: "${TIMEZONE}"
             probes:
@@ -62,8 +63,10 @@ spec:
               requests:
                 cpu: 10m
                 memory: 256Mi
+                gpu.intel.com/i915: 1
               limits:
                 memory: 1Gi
+                gpu.intel.com/i915: 1
     service:
       ersatztv-next:
         controller: *name

--- a/kubernetes/apps/media/ersatztv-next/helm-release.yaml
+++ b/kubernetes/apps/media/ersatztv-next/helm-release.yaml
@@ -44,7 +44,7 @@ spec:
           ersatztv-next:
             image:
               repository: ghcr.io/ersatztv/ersatztv-next
-              tag: latest
+              tag: develop
             env:
               TZ: "${TIMEZONE}"
             probes:
@@ -85,35 +85,4 @@ spec:
               - path: /data
                 subPath: .
                 readOnly: true
-      tmp:
-        enabled: true
-        type: emptyDir
-    networkpolicies:
-      ersatztv-next:
-        enabled: true
-        controller: *name
-        policyTypes:
-          - Ingress
-          - Egress
-        rules:
-          egress:
-            - to:
-                - namespaceSelector:
-                    matchLabels:
-                      kubernetes.io/metadata.name: kube-system
-                  podSelector:
-                    matchLabels:
-                      k8s-app: kube-dns
-              ports:
-                - port: 53
-                  protocol: UDP
-          ingress:
-            - from:
-                - namespaceSelector:
-                    matchLabels:
-                      kubernetes.io/metadata.name: haproxy-controller
-                  podSelector:
-                    matchLabels:
-                      app.kubernetes.io/name: kubernetes-ingress
-              ports:
-                - port: *port
+

--- a/kubernetes/apps/media/ersatztv-next/helm-release.yaml
+++ b/kubernetes/apps/media/ersatztv-next/helm-release.yaml
@@ -44,8 +44,7 @@ spec:
           ersatztv-next:
             image:
               repository: ghcr.io/ersatztv/next
-              tag: develop
-              digest: sha256:61e87806bb3d4f05c24b84996f4815d6029b3bbf67d323f3ac8e637bec8489d5
+              tag: develop@sha256:61e87806bb3d4f05c24b84996f4815d6029b3bbf67d323f3ac8e637bec8489d5
             env:
               TZ: "${TIMEZONE}"
             probes:

--- a/kubernetes/apps/media/ersatztv-next/helm-release.yaml
+++ b/kubernetes/apps/media/ersatztv-next/helm-release.yaml
@@ -43,9 +43,9 @@ spec:
         containers:
           ersatztv-next:
             image:
-              repository: ghcr.io/ersatztv/ersatztv-next
+              repository: ghcr.io/ersatztv/next
               tag: develop
-              # digest: sha256:TODO — pin after pulling (image requires GHCR auth)
+              digest: sha256:61e87806bb3d4f05c24b84996f4815d6029b3bbf67d323f3ac8e637bec8489d5
             env:
               TZ: "${TIMEZONE}"
             probes:

--- a/kubernetes/apps/media/ersatztv-next/helm-release.yaml
+++ b/kubernetes/apps/media/ersatztv-next/helm-release.yaml
@@ -93,6 +93,7 @@ spec:
         controller: *name
         policyTypes:
           - Ingress
+          - Egress
         rules:
           ingress:
             - from:

--- a/kubernetes/apps/media/ersatztv-next/kustomization.yaml
+++ b/kubernetes/apps/media/ersatztv-next/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml
+  - pvc.yaml
+  - volsync.yaml

--- a/kubernetes/apps/media/ersatztv-next/pvc.yaml
+++ b/kubernetes/apps/media/ersatztv-next/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ersatztv-next
+  namespace: media
+spec:
+  storageClassName: "${STORAGE_READWRITEONCE}"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/kubernetes/apps/media/ersatztv-next/volsync.yaml
+++ b/kubernetes/apps/media/ersatztv-next/volsync.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name ersatztv-next-restic
+  namespace: &namespace media
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: raw
+      version: v0.3.2
+      sourceRef:
+        kind: HelmRepository
+        name: dysnix-charts
+        namespace: flux-system
+      interval: 30m
+  driftDetection:
+    mode: enabled
+  targetNamespace: media
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    remediation:
+      retries: 10
+  dependsOn:
+    - name: volsync
+      namespace: flux-system
+    - name: ersatztv-next
+      namespace: flux-system
+  values:
+    resources:
+      - apiVersion: v1
+        kind: Secret
+        metadata:
+          name: ersatztv-next-volsync-secret
+          namespace: media
+        type: Opaque
+        stringData:
+          RESTIC_REPOSITORY: "s3:${SECRET_S3_VOLSYNC_URL}/volsync-${CLUSTER_NAME}/ersatztv-next"
+          RESTIC_PASSWORD: "${SECRET_VOLSYNC_RESTIC_PWD}"
+          AWS_ACCESS_KEY_ID: "${SECRET_S3_VOLSYNC_ACCESS_KEYS}"
+          AWS_SECRET_ACCESS_KEY: "${SECRET_S3_VOLSYNC_SECRET_KEYS}"
+      - apiVersion: volsync.backube/v1alpha1
+        kind: ReplicationSource
+        metadata:
+          name: *name
+          namespace: *namespace
+        spec:
+          sourcePVC: ersatztv-next
+          trigger:
+            schedule: "14 01 * * *"
+          restic:
+            copyMethod: Direct
+            pruneIntervalDays: 7
+            repository: ersatztv-next-volsync-secret
+            moverSecurityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
+              fsGroup: 1000
+              fsGroupChangePolicy: "OnRootMismatch"
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+            retain:
+              daily: 7
+              within: 3d
+      - apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        metadata:
+          name: *name
+          namespace: *namespace
+        spec:
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/created-by: volsync
+          policyTypes:
+            - Ingress
+            - Egress
+          ingress: []
+          egress:
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+                  podSelector:
+                    matchLabels:
+                      k8s-app: kube-dns
+              ports:
+                - port: 53
+                  protocol: UDP
+            - to: # S3-Backup
+              - ipBlock:
+                  cidr: 10.0.1.75/32
+              ports:
+                - port: 3900
+                  protocol: TCP

--- a/kubernetes/apps/media/jellyfin/helm-release.yaml
+++ b/kubernetes/apps/media/jellyfin/helm-release.yaml
@@ -170,6 +170,14 @@ spec:
               ports:
                 - port: 8409
             - to:
+                - podSelector:
+                    matchLabels:
+                      app.kubernetes.io/controller: ersatztv-next
+                      app.kubernetes.io/instance: media-ersatztv-next
+                      app.kubernetes.io/name: media-ersatztv-next
+              ports:
+                - port: 8409
+            - to:
                 - namespaceSelector:
                     matchLabels:
                       kubernetes.io/metadata.name: mailrelay

--- a/kubernetes/apps/media/kustomization.yaml
+++ b/kubernetes/apps/media/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - beets
   - cronjobs
   - ersatztv
+  - ersatztv-next
   - fetcharr
   - filebrowser
   - gogrepoc


### PR DESCRIPTION
Adds ErsatzTV Next — a Rust rewrite of ErsatzTV. Config-driven (TOML), no web UI.

- Port 8409 (same as legacy ErsatzTV)
- Image: `ghcr.io/ersatztv/ersatztv-next:latest`
- Config PVC (1Gi RWO) + read-only mount of shared media PVC
- VolSync backup for config volume
- No ingress — IPTV streams consumed directly by clients/Jellyfin

**Note:** Image digest not pinned — ghcr.io package requires authentication to inspect. Pin once publicly accessible. Playout JSON must be pre-generated via `ersatztv-playout-generator` (included in image) and placed in /config.