### PR TITLE
feat(hermes-agent): deploy NousResearch Hermes Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Every namespace has a default-deny network policy. Ingress and egress are explic
 ### AI & Search
 | Service | Purpose |
 |---------|---------|
+| [Hermes Agent](https://hermes-agent.nousresearch.com) | Self-improving AI agent (NousResearch) |
 | [LiteLLM](https://litellm.ai/) | OpenAI-compatible LLM proxy (GitHub Copilot gateway) |
 | [Ollama](https://ollama.ai/) | Local LLM inference |
 | [Open WebUI](https://openwebui.com/) | Chat interface for local models |

--- a/kubernetes/apps/hermes-agent/helm-release.yaml
+++ b/kubernetes/apps/hermes-agent/helm-release.yaml
@@ -44,7 +44,7 @@ spec:
           hermes-agent:
             image:
               repository: docker.io/nousresearch/hermes-agent
-              tag: latest@sha256:7b4fead641f433cd0fe1fbfadf129e9ef416e345a6e0ee91ebacaa10e402119f
+              tag: v2026.4.16@sha256:e006a640df03b885f88232de59d7f958108e43ac639b2499a78bb3fdd622e550
             env:
               TZ: "${TIMEZONE}"
             probes:

--- a/kubernetes/apps/hermes-agent/helm-release.yaml
+++ b/kubernetes/apps/hermes-agent/helm-release.yaml
@@ -71,7 +71,7 @@ spec:
                   failureThreshold: 30
             securityContext:
               allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: false  # Agent writes to /opt/data and runtime dirs
+              readOnlyRootFilesystem: true
               capabilities:
                 drop:
                   - ALL
@@ -113,6 +113,9 @@ spec:
         existingClaim: hermes-agent
         globalMounts:
           - path: /opt/data
+      tmp:
+        enabled: true
+        type: emptyDir
     networkpolicies:
       hermes-agent:
         enabled: true
@@ -138,21 +141,19 @@ spec:
                       kubernetes.io/metadata.name: litellm
                   podSelector:
                     matchLabels:
+                      app.kubernetes.io/controller: litellm
+                      app.kubernetes.io/instance: litellm-litellm
                       app.kubernetes.io/name: litellm-litellm
               ports:
                 - port: 4000
                   protocol: TCP
-            - to:
-                - ipBlock:
-                    cidr: 0.0.0.0/0
-                    except:
-                      - 10.0.0.0/8
-                      - 172.16.0.0/12
-                      - 192.168.0.0/16
+            - to: # External API access
+              - ipBlock:
+                  cidr: 0.0.0.0/0
+                  except:
+                  - "${HAPROXY_WHITELIST}"
               ports:
                 - port: 443
-                  protocol: TCP
-                - port: 80
                   protocol: TCP
           ingress:
             - from:

--- a/kubernetes/apps/hermes-agent/helm-release.yaml
+++ b/kubernetes/apps/hermes-agent/helm-release.yaml
@@ -133,6 +133,16 @@ spec:
                 - port: 53
                   protocol: UDP
             - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: litellm
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: litellm-litellm
+              ports:
+                - port: 4000
+                  protocol: TCP
+            - to:
                 - ipBlock:
                     cidr: 0.0.0.0/0
                     except:

--- a/kubernetes/apps/hermes-agent/helm-release.yaml
+++ b/kubernetes/apps/hermes-agent/helm-release.yaml
@@ -1,0 +1,156 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name hermes-agent
+  namespace: flux-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.6.2
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s-charts
+        namespace: flux-system
+      interval: 30m
+  driftDetection:
+    mode: enabled
+  targetNamespace: hermes-agent
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    remediation:
+      retries: 10
+  values:
+    fullnameOverride: *name
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      hermes-agent:
+        containers:
+          hermes-agent:
+            image:
+              repository: docker.io/nousresearch/hermes-agent
+              tag: latest@sha256:7b4fead641f433cd0fe1fbfadf129e9ef416e345a6e0ee91ebacaa10e402119f
+            env:
+              TZ: "${TIMEZONE}"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &port 8642
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  failureThreshold: 5
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: false  # Agent writes to /opt/data and runtime dirs
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 50m
+              limits:
+                memory: 1Gi
+    service:
+      hermes-agent:
+        controller: *name
+        ports:
+          http:
+            port: *port
+    ingress:
+      hermes-agent:
+        enabled: true
+        annotations:
+          haproxy.org/allow-list: "${HAPROXY_WHITELIST}"
+          haproxy.org/ssl-redirect-port: "443"
+          haproxy.org/response-set-header: |
+            Strict-Transport-Security "max-age=31536000"
+            X-Frame-Options "DENY"
+            X-Content-Type-Options "nosniff"
+            Referrer-Policy "strict-origin-when-cross-origin"
+        hosts:
+          - host: &host "hermes-agent.${SECRET_DEFAULT_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: hermes-agent
+                  port: http
+        tls:
+          - hosts:
+              - *host
+    persistence:
+      opt:
+        enabled: true
+        existingClaim: hermes-agent
+        globalMounts:
+          - path: /opt/data
+    networkpolicies:
+      hermes-agent:
+        enabled: true
+        controller: *name
+        policyTypes:
+          - Egress
+          - Ingress
+        rules:
+          egress:
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+                  podSelector:
+                    matchLabels:
+                      k8s-app: kube-dns
+              ports:
+                - port: 53
+                  protocol: UDP
+            - to:
+                - ipBlock:
+                    cidr: 0.0.0.0/0
+                    except:
+                      - 10.0.0.0/8
+                      - 172.16.0.0/12
+                      - 192.168.0.0/16
+              ports:
+                - port: 443
+                  protocol: TCP
+                - port: 80
+                  protocol: TCP
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: haproxy-controller
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: kubernetes-ingress
+              ports:
+                - port: *port

--- a/kubernetes/apps/hermes-agent/helm-release.yaml
+++ b/kubernetes/apps/hermes-agent/helm-release.yaml
@@ -1,0 +1,161 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name hermes-agent
+  namespace: flux-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 5.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s-charts
+        namespace: flux-system
+      interval: 30m
+  driftDetection:
+    mode: enabled
+  targetNamespace: hermes-agent
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    remediation:
+      retries: 10
+  values:
+    global:
+      createDefaultServiceAccount: false
+    fullnameOverride: *name
+    defaultPodOptions:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+        fsGroupChangePolicy: "OnRootMismatch"
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+    controllers:
+      hermes-agent:
+        containers:
+          hermes-agent:
+            image:
+              repository: docker.io/nousresearch/hermes-agent
+              tag: v2026.5.7@sha256:9462082533e603fc6ba4259c51d7722dcd8cbb0f348488ceedc35d06fa8f9324
+            env:
+              TZ: "${TIMEZONE}"
+            probes:
+              liveness: &probes
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: &port 8642
+                  initialDelaySeconds: 30
+                  periodSeconds: 30
+                  failureThreshold: 5
+              readiness: *probes
+              startup:
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /health
+                    port: *port
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  failureThreshold: 30
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+            resources:
+              requests:
+                cpu: 50m
+              limits:
+                memory: 1Gi
+    service:
+      hermes-agent:
+        controller: *name
+        ports:
+          http:
+            port: *port
+    ingress:
+      hermes-agent:
+        enabled: true
+        annotations:
+          haproxy.org/allow-list: "${HAPROXY_WHITELIST}"
+          haproxy.org/ssl-redirect-port: "443"
+          haproxy.org/response-set-header: |
+            Strict-Transport-Security "max-age=31536000"
+            X-Frame-Options "DENY"
+            X-Content-Type-Options "nosniff"
+            Referrer-Policy "strict-origin-when-cross-origin"
+        hosts:
+          - host: &host "hermes-agent.${SECRET_DEFAULT_DOMAIN}"
+            paths:
+              - path: /
+                service:
+                  identifier: hermes-agent
+                  port: http
+        tls:
+          - hosts:
+              - *host
+    persistence:
+      opt:
+        enabled: true
+        existingClaim: hermes-agent
+        globalMounts:
+          - path: /opt/data
+      tmp:
+        enabled: true
+        type: emptyDir
+    networkpolicies:
+      hermes-agent:
+        enabled: true
+        controller: *name
+        policyTypes:
+          - Egress
+          - Ingress
+        rules:
+          egress:
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+                  podSelector:
+                    matchLabels:
+                      k8s-app: kube-dns
+              ports:
+                - port: 53
+                  protocol: UDP
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: litellm
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/controller: litellm
+                      app.kubernetes.io/instance: litellm-litellm
+                      app.kubernetes.io/name: litellm-litellm
+              ports:
+                - port: 4000
+                  protocol: TCP
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: haproxy-controller
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/name: kubernetes-ingress
+              ports:
+                - port: *port

--- a/kubernetes/apps/hermes-agent/kustomization.yaml
+++ b/kubernetes/apps/hermes-agent/kustomization.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helm-release.yaml
+  - namespace.yaml
+  - networkpolicy.yaml
+  - probes.yaml
+  - pvc.yaml
+  - volsync.yaml

--- a/kubernetes/apps/hermes-agent/namespace.yaml
+++ b/kubernetes/apps/hermes-agent/namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hermes-agent

--- a/kubernetes/apps/hermes-agent/networkpolicy.yaml
+++ b/kubernetes/apps/hermes-agent/networkpolicy.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: hermes-agent
+spec:
+  podSelector: {}
+  policyTypes:
+    - Ingress
+    - Egress

--- a/kubernetes/apps/hermes-agent/probes.yaml
+++ b/kubernetes/apps/hermes-agent/probes.yaml
@@ -1,0 +1,47 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: probe
+  namespace: hermes-agent
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: raw
+      version: v0.3.2
+      sourceRef:
+        kind: HelmRepository
+        name: dysnix-charts
+        namespace: flux-system
+      interval: 30m
+  targetNamespace: hermes-agent
+  driftDetection:
+    mode: enabled
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    remediation:
+      retries: 10
+  dependsOn:
+    - name: kube-prometheus-stack-crds
+      namespace: flux-system
+    - name: blackbox-exporter
+      namespace: flux-system
+  values:
+    resources:
+      - apiVersion: monitoring.coreos.com/v1
+        kind: Probe
+        metadata:
+          name: urlmonitoring
+          namespace: hermes-agent
+        spec:
+          module: http_2xx
+          prober:
+            url: "${BLACKBOX_EXPORTER_URL}"
+          targets:
+            staticConfig:
+              static:
+                - "https://hermes-agent.${SECRET_DEFAULT_DOMAIN}"

--- a/kubernetes/apps/hermes-agent/pvc.yaml
+++ b/kubernetes/apps/hermes-agent/pvc.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: hermes-agent
+  namespace: hermes-agent
+spec:
+  storageClassName: "${STORAGE_READWRITEONCE}"
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/kubernetes/apps/hermes-agent/volsync.yaml
+++ b/kubernetes/apps/hermes-agent/volsync.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &name hermes-agent-restic
+  namespace: &namespace hermes-agent
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: raw
+      version: v0.3.2
+      sourceRef:
+        kind: HelmRepository
+        name: dysnix-charts
+        namespace: flux-system
+      interval: 30m
+  driftDetection:
+    mode: enabled
+  targetNamespace: hermes-agent
+  install:
+    createNamespace: true
+    remediation:
+      retries: 10
+  upgrade:
+    remediation:
+      retries: 10
+  dependsOn:
+    - name: volsync
+      namespace: flux-system
+    - name: hermes-agent
+      namespace: flux-system
+  values:
+    resources:
+      - apiVersion: v1
+        kind: Secret
+        metadata:
+          name: hermes-agent-volsync-secret
+          namespace: hermes-agent
+        type: Opaque
+        stringData:
+          RESTIC_REPOSITORY: "s3:${SECRET_S3_VOLSYNC_URL}/volsync-${CLUSTER_NAME}/hermes-agent"
+          RESTIC_PASSWORD: "${SECRET_VOLSYNC_RESTIC_PWD}"
+          AWS_ACCESS_KEY_ID: "${SECRET_S3_VOLSYNC_ACCESS_KEYS}"
+          AWS_SECRET_ACCESS_KEY: "${SECRET_S3_VOLSYNC_SECRET_KEYS}"
+      - apiVersion: volsync.backube/v1alpha1
+        kind: ReplicationSource
+        metadata:
+          name: *name
+          namespace: *namespace
+        spec:
+          sourcePVC: hermes-agent
+          trigger:
+            schedule: "17 02 * * *"
+          restic:
+            copyMethod: Direct
+            pruneIntervalDays: 7
+            repository: hermes-agent-volsync-secret
+            moverSecurityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
+              fsGroup: 1000
+              fsGroupChangePolicy: "OnRootMismatch"
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+            retain:
+              daily: 7
+              within: 3d
+      - apiVersion: networking.k8s.io/v1
+        kind: NetworkPolicy
+        metadata:
+          name: *name
+          namespace: *namespace
+        spec:
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/created-by: volsync
+          policyTypes:
+            - Ingress
+            - Egress
+          ingress: []
+          egress:
+            - to:
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: kube-system
+                  podSelector:
+                    matchLabels:
+                      k8s-app: kube-dns
+              ports:
+                - port: 53
+                  protocol: UDP
+            - to: # S3-Backup
+              - ipBlock:
+                  cidr: 10.0.1.75/32
+              ports:
+                - port: 3900
+                  protocol: TCP

--- a/kubernetes/apps/homeprod/kustomization.yaml
+++ b/kubernetes/apps/homeprod/kustomization.yaml
@@ -22,6 +22,7 @@ resources:
   - ../freshrss
   - ../gotify
   - ../ha-mcp
+  - ../hermes-agent
   - ../icloudpd
   - ../intel-device-plugin
   - ../invidious

--- a/kubernetes/apps/litellm/helm-release.yaml
+++ b/kubernetes/apps/litellm/helm-release.yaml
@@ -213,5 +213,13 @@ spec:
                       app.kubernetes.io/controller: wallos
                       app.kubernetes.io/instance: wallos-wallos
                       app.kubernetes.io/name: wallos-wallos
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: hermes-agent
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/controller: hermes-agent
+                      app.kubernetes.io/instance: hermes-agent-hermes-agent
+                      app.kubernetes.io/name: hermes-agent-hermes-agent
               ports:
                 - port: *port

--- a/kubernetes/apps/litellm/helm-release.yaml
+++ b/kubernetes/apps/litellm/helm-release.yaml
@@ -280,5 +280,13 @@ spec:
                       app.kubernetes.io/controller: wallos
                       app.kubernetes.io/instance: wallos-wallos
                       app.kubernetes.io/name: wallos-wallos
+                - namespaceSelector:
+                    matchLabels:
+                      kubernetes.io/metadata.name: hermes-agent
+                  podSelector:
+                    matchLabels:
+                      app.kubernetes.io/controller: hermes-agent
+                      app.kubernetes.io/instance: hermes-agent-hermes-agent
+                      app.kubernetes.io/name: hermes-agent-hermes-agent
               ports:
                 - port: *port


### PR DESCRIPTION
Deploys [Hermes Agent](https://hermes-agent.nousresearch.com) by NousResearch — a self-improving AI agent with a built-in learning loop.

Runs in gateway mode (port 8642), data persisted at `/opt/data`. Includes ingress, VolSync backup, blackbox probe, default-deny + per-app network policies.

**Note:** Requires initial setup before gateway mode works — run the setup wizard interactively once to configure API keys in `/opt/data/.env`. See [Docker docs](https://hermes-agent.nousresearch.com/docs/user-guide/docker/).